### PR TITLE
Add AccessToken field to user

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -19,7 +19,8 @@ var input1 = []byte(`{
       }]
     }],
     "user":{
-      "user_id":"1502731363742",
+      "accessToken":"a75c98e4dbc6f53856ab527f24a62237e7",
+      "userId":"1502731363742",
       "permissions":[],
       "locale":"en-US"
     },
@@ -90,7 +91,8 @@ var input2 = []byte(`{
       }]
     }],
     "user":{
-      "user_id":"1502774951934",
+      "userId":"1502774951934",
+      "accessToken":"a75c98e43aba71dbc6f53b527f24a62237e7",
       "permissions":[],
       "locale":"en-US"
     },

--- a/request.go
+++ b/request.go
@@ -27,8 +27,9 @@ type RawInput struct {
 }
 
 type User struct {
-	ID     string `json:"user_id"`
-	Locale string `json:locale`
+	ID          string `json:"userId"`
+	Locale      string `json:locale`
+	AccessToken string `json:"accessToken"`
 }
 
 type Result struct {

--- a/request_test.go
+++ b/request_test.go
@@ -19,6 +19,10 @@ func Test_1(t *testing.T) {
 		t.Errorf("Wrong User ID : %s", originalRequest.Data.User.ID)
 		return
 	}
+	if originalRequest.Data.User.AccessToken != "a75c98e4dbc6f53856ab527f24a62237e7" {
+		t.Errorf("Wrong User AccessToken : %s", originalRequest.Data.User.AccessToken)
+		return
+	}
 	if originalRequest.Data.User.Locale != "en-US" {
 		t.Errorf("Wrong User Locale : %s", originalRequest.Data.User.Locale)
 		return
@@ -56,7 +60,6 @@ func Test_1(t *testing.T) {
 		t.Errorf("Wrong Speech : %s", msg.Speech)
 		return
 	}
-	t.Errorf("OK")
 }
 
 func Test_2(t *testing.T) {


### PR DESCRIPTION
When building an app with account linking, the access token to your service is passed in the `accessToken` field inside the User json. The user id parameter was also not coming through as the tag was wrong on it. 